### PR TITLE
3d to uv border

### DIFF
--- a/pam/grid.py
+++ b/pam/grid.py
@@ -272,6 +272,7 @@ class UVGrid(object):
         if uv[0] >= self._u or uv[1] >= self._v or uv[0] < 0.0 or uv[1] < 0.0:
             uv[0] = min(self._u, max(0., uv[0]))
             uv[1] = min(self._v, max(0., uv[1]))
+            #print("UV adjusted")
         return uv
 
     def _uv_to_cell_index(self, u, v):

--- a/pam/grid.py
+++ b/pam/grid.py
@@ -231,8 +231,11 @@ class UVGrid(object):
         :rtype: list
 
         """
-        if uv[0] >= self._u or uv[1] >= self._v or uv[0] < 0.0 or uv[1] < 0.0:
-            return []
+        #if uv[0] > self._u or uv[1] > self._v or uv[0] < 0.0 or uv[1] < 0.0:
+            #return []
+
+        uv = self.adjustUV(uv)    #if an error occurs in the 3d to uv mapping, it is because of float precision -> small error
+                                  #dealt with by just setting the deviating coordinate onto the border.
 
         row, col = self._uv_to_cell_index(uv[0], uv[1])
         if row == -1:
@@ -266,14 +269,14 @@ class UVGrid(object):
         :rtype: tuple (float, float)
 
         """
-        if uv[0] >= self._u or vv[1] >= self._v or uv[0] < 0.0 or vv[0] < 0.0:
+        if uv[0] >= self._u or uv[1] >= self._v or uv[0] < 0.0 or uv[1] < 0.0:
             uv[0] = min(self._u, max(0., uv[0]))
-            uv[1] = min(self._v, max(0., vv[0]))
+            uv[1] = min(self._v, max(0., uv[1]))
         return uv
 
     def _uv_to_cell_index(self, u, v):
         """Returns cell index for a uv coordinate"""
-        if u >= self._u or v >= self._v or u < 0.0 or v < 0.0:
+        if u > self._u or v > self._v or u < 0.0 or v < 0.0:
             # logger.error("uv coordinate out of bounds (%f, %f)", u, v)
             return -1, -1
             # u = min(self._u, max(0., u))

--- a/pam/pam.py
+++ b/pam/pam.py
@@ -119,6 +119,30 @@ def computeUVScalingFactor(obj):
     # TODO (MP): compute scaling factor on the basis of all edges
     return numpy.mean(result), result
 
+def checkPointOnLine(p,a1,a2):
+    """Checks if a point p is on the line between the points a1 and a2
+    returns boolean
+
+    """
+    EPSILON = 0.0001     #tolerance value for being able to work with floats
+    d1 = p-a1
+    d2 = a2-p
+    dot = numpy.dot(d1,d2)
+    #print('dot',dot)
+    cross = numpy.cross(d1,d2)
+    #print('cross',cross)
+    norma1a2 = numpy.linalg.norm(a2-a1)
+    #print('norma1a2',norma1a2)
+    if numpy.linalg.norm(cross) > EPSILON:        #greater than 0, with tolerance
+        #print('First false')
+        return False
+    if dot < -EPSILON:                   #lesser than 0, with tolerance
+        #print('Second false')
+        return False
+    if dot > norma1a2*norma1a2+EPSILON:       #greater that squared norm, with tolerance
+        #print('Third false')
+        return False
+    return True
 
 # TODO(SK): Quads into triangles (indices)
 # TODO(SK): Rephrase docstring, add parameter/return values
@@ -156,7 +180,10 @@ def map3dPointToUV(obj, obj_uv, point, normal=None):
 
     # if the point is not within the first triangle, we have to repeat the calculation
     # for the second triangle
-    if (mathutils.geometry.intersect_point_tri_2d(p_uv.to_2d(), uvs[0].uv, uvs[1].uv, uvs[2].uv) == 0) & (len(uvs) == 4):
+    if (mathutils.geometry.intersect_point_tri_2d(p_uv.to_2d(), uvs[0].uv, uvs[1].uv, uvs[2].uv) == 0) & \
+            (checkPointOnLine(p_uv.to_2d(),uvs[0].uv,uvs[1].uv) == False) & \
+            (checkPointOnLine(p_uv.to_2d(),uvs[0].uv,uvs[2].uv) == False) & \
+            (checkPointOnLine(p_uv.to_2d(),uvs[1].uv,uvs[2].uv) == False) & (len(uvs) == 4):
         A = obj.data.vertices[obj.data.polygons[f].vertices[0]].co
         B = obj.data.vertices[obj.data.polygons[f].vertices[2]].co
         C = obj.data.vertices[obj.data.polygons[f].vertices[3]].co

--- a/pam/pam.py
+++ b/pam/pam.py
@@ -121,7 +121,7 @@ def computeUVScalingFactor(obj):
 
 def checkPointOnLine(p,a1,a2):
     """Checks if a point p is on the line between the points a1 and a2
-    returns boolean
+    returns the qualitative distance of the point from the line, 0 if the point is on the line with tolerance
 
     """
     EPSILON = 0.0001     #tolerance value for being able to work with floats
@@ -133,16 +133,19 @@ def checkPointOnLine(p,a1,a2):
     #print('cross',cross)
     norma1a2 = numpy.linalg.norm(a2-a1)
     #print('norma1a2',norma1a2)
-    if numpy.linalg.norm(cross) > EPSILON:        #greater than 0, with tolerance
+    delta = numpy.linalg.norm(cross) - EPSILON
+    if delta > 0:        #greater than 0, with tolerance
         #print('First false')
-        return False
-    if dot < -EPSILON:                   #lesser than 0, with tolerance
+        return delta
+    delta = -EPSILON-dot
+    if delta > 0:                   #lesser than 0, with tolerance
         #print('Second false')
-        return False
-    if dot > norma1a2*norma1a2+EPSILON:       #greater that squared norm, with tolerance
+        return delta
+    delta = dot-norma1a2*norma1a2+EPSILON
+    if delta > 0:       #greater that squared norm, with tolerance
         #print('Third false')
-        return False
-    return True
+        return delta
+    return 0
 
 # TODO(SK): Quads into triangles (indices)
 # TODO(SK): Rephrase docstring, add parameter/return values
@@ -178,12 +181,15 @@ def map3dPointToUV(obj, obj_uv, point, normal=None):
     # convert 3d-coordinates of point p to uv-coordinates
     p_uv = mathutils.geometry.barycentric_transform(p, A, B, C, U, V, W)
 
+    p_uv_2d = p_uv.to_2d()
+    delta1 = checkPointOnLine(p_uv_2d,uvs[0].uv,uvs[1].uv)
+    delta2 = checkPointOnLine(p_uv_2d,uvs[0].uv,uvs[2].uv)
+    delta3 = checkPointOnLine(p_uv_2d,uvs[1].uv,uvs[2].uv)
+    delta = min(delta1,delta2,delta3)
+
     # if the point is not within the first triangle, we have to repeat the calculation
     # for the second triangle
-    if (mathutils.geometry.intersect_point_tri_2d(p_uv.to_2d(), uvs[0].uv, uvs[1].uv, uvs[2].uv) == 0) & \
-            (checkPointOnLine(p_uv.to_2d(),uvs[0].uv,uvs[1].uv) == False) & \
-            (checkPointOnLine(p_uv.to_2d(),uvs[0].uv,uvs[2].uv) == False) & \
-            (checkPointOnLine(p_uv.to_2d(),uvs[1].uv,uvs[2].uv) == False) & (len(uvs) == 4):
+    if (mathutils.geometry.intersect_point_tri_2d(p_uv_2d, uvs[0].uv, uvs[1].uv, uvs[2].uv) == 0) & (delta != 0) & (len(uvs) == 4):
         A = obj.data.vertices[obj.data.polygons[f].vertices[0]].co
         B = obj.data.vertices[obj.data.polygons[f].vertices[2]].co
         C = obj.data.vertices[obj.data.polygons[f].vertices[3]].co
@@ -192,9 +198,22 @@ def map3dPointToUV(obj, obj_uv, point, normal=None):
         V = uvs[2].uv.to_3d()
         W = uvs[3].uv.to_3d()
 
-        p_uv = mathutils.geometry.barycentric_transform(p, A, B, C, U, V, W)
+        p_uv_new = mathutils.geometry.barycentric_transform(p, A, B, C, U, V, W)
 
-    return p_uv.to_2d()
+    else:
+        return p_uv_2d
+
+    p_uv_2d_new = p_uv_new.to_2d()
+    delta1 = checkPointOnLine(p_uv_2d_new,uvs[0].uv,uvs[1].uv)
+    delta2 = checkPointOnLine(p_uv_2d_new,uvs[0].uv,uvs[2].uv)
+    delta3 = checkPointOnLine(p_uv_2d_new,uvs[1].uv,uvs[2].uv)
+    delta_new = min(delta1,delta2,delta3)
+
+    if (mathutils.geometry.intersect_point_tri_2d(p_uv_2d, uvs[0].uv, uvs[1].uv, uvs[2].uv) == 0) & (delta != 0) & (len(uvs) == 4):
+        if delta_new < delta:
+            return p_uv_2d_new
+        return p_uv_2d
+    return p_uv_2d_new
 
 
 # TODO(SK): Quads into triangles (indices)


### PR DESCRIPTION
SHORT VERSION: 3d to UV function now accepts points that are on the triangle border.

DETAILED VERSION: In map3dPointToUV() (pam.py), which is used for mapping operations, the blender function closest_point_on_mesh() of the object class is used. When called properly, the function always return a valid point that lies on the mesh. Thus, the barycentric transformation to UV always results in a point within the UV mesh. Nevertheless, map3dPointToUV() sometimes returned invalid points that got discarded by grid.select_random() (grid.py) because it was out of UV bounds. This happened because the Blender function mathutils.geometry.intersect_point_tri_2d() used in map3dPointToUV() does not take the triangle border into account (because there is no exact equality in float calculations). A function that checks the border with a certain tolerance value is added. If there is still no point found (this is possible in some cases because the tolerance value could not be perfectly traded off with the triangle selection accuracy), the one with the smaller deviation from the border is returned. In grid.select_random() the test for border violation is replaced by adjusting deviating points onto the border.
The added functionality is not completely runtime optimised, but as this is not one of the key features of PAM, this may be ok.
